### PR TITLE
Add hideout progress endpoints for modules and parts

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -94,6 +94,8 @@ async function getApiApp(): Promise<Express> {
   app.post('/api/progress/task/:taskId', progressHandler.updateSingleTask);
   app.post('/api/progress/tasks', progressHandler.updateMultipleTasks);
   app.post('/api/progress/task/objective/:objectiveId', progressHandler.updateTaskObjective);
+  app.post('/api/progress/hideout/module/:moduleId', progressHandler.updateHideoutModule);
+  app.post('/api/progress/hideout/part/:partId', progressHandler.updateHideoutPart);
   app.options('/api/team/create', (_req: ExpressRequest, res: ExpressResponse) => {
     res.status(200).send();
   });
@@ -113,6 +115,8 @@ async function getApiApp(): Promise<Express> {
   app.post('/api/v2/progress/task/:taskId', progressHandler.updateSingleTask);
   app.post('/api/v2/progress/tasks', progressHandler.updateMultipleTasks);
   app.post('/api/v2/progress/task/objective/:objectiveId', progressHandler.updateTaskObjective);
+  app.post('/api/v2/progress/hideout/module/:moduleId', progressHandler.updateHideoutModule);
+  app.post('/api/v2/progress/hideout/part/:partId', progressHandler.updateHideoutPart);
   app.get(
     '/health',
     asyncHandler(async (_req: ExpressRequest, res: ExpressResponse) => {

--- a/functions/src/services/ValidationService.ts
+++ b/functions/src/services/ValidationService.ts
@@ -3,6 +3,9 @@ import {
   TaskUpdateRequest, 
   MultipleTaskUpdateRequest, 
   ObjectiveUpdateRequest,
+  HideoutModuleStatus,
+  HideoutModuleUpdateRequest,
+  HideoutPartUpdateRequest,
   ApiToken 
 } from '../types/api.js';
 import { errors } from '../middleware/errorHandler.js';
@@ -117,6 +120,70 @@ export class ValidationService {
   }
 
   /**
+   * Validates hideout module status values
+   */
+  static validateHideoutModuleStatus(status: unknown): status is HideoutModuleStatus {
+    return typeof status === 'string' && 
+           (status === 'completed' || status === 'uncompleted');
+  }
+
+  /**
+   * Validates and sanitizes hideout module update request
+   */
+  static validateHideoutModuleUpdate(body: unknown): HideoutModuleUpdateRequest {
+    if (!body || typeof body !== 'object') {
+      throw errors.badRequest('Request body is required');
+    }
+
+    const { state } = body as { state?: unknown };
+
+    if (!state) {
+      throw errors.badRequest('State is required');
+    }
+
+    if (!this.validateHideoutModuleStatus(state)) {
+      throw errors.badRequest(
+        "Invalid state provided. Must be 'completed' or 'uncompleted'"
+      );
+    }
+
+    return { state };
+  }
+
+  /**
+   * Validates hideout part update request
+   */
+  static validateHideoutPartUpdate(body: unknown): HideoutPartUpdateRequest {
+    if (!body || typeof body !== 'object') {
+      throw errors.badRequest('Request body is required');
+    }
+
+    const { state, count } = body as { state?: unknown; count?: unknown };
+
+    if (!state && count == null) {
+      throw errors.badRequest('Either state or count must be provided');
+    }
+
+    const update: HideoutPartUpdateRequest = {};
+
+    if (state) {
+      if (state !== 'completed' && state !== 'uncompleted') {
+        throw errors.badRequest('State must be "completed" or "uncompleted"');
+      }
+      update.state = state;
+    }
+
+    if (count != null) {
+      if (typeof count !== 'number' || count < 0 || !Number.isInteger(count)) {
+        throw errors.badRequest('Count must be a non-negative integer');
+      }
+      update.count = count;
+    }
+
+    return update;
+  }
+
+  /**
    * Validates task ID parameter
    */
   static validateTaskId(taskId: string): string {
@@ -124,6 +191,26 @@ export class ValidationService {
       throw errors.badRequest('Task ID is required and must be a non-empty string');
     }
     return taskId.trim();
+  }
+
+  /**
+   * Validates hideout module ID parameter
+   */
+  static validateModuleId(moduleId: string): string {
+    if (!moduleId || typeof moduleId !== 'string' || moduleId.trim().length === 0) {
+      throw errors.badRequest('Module ID is required and must be a non-empty string');
+    }
+    return moduleId.trim();
+  }
+
+  /**
+   * Validates hideout part ID parameter
+   */
+  static validatePartId(partId: string): string {
+    if (!partId || typeof partId !== 'string' || partId.trim().length === 0) {
+      throw errors.badRequest('Part ID is required and must be a non-empty string');
+    }
+    return partId.trim();
   }
 
   /**

--- a/functions/src/types/api.ts
+++ b/functions/src/types/api.ts
@@ -144,6 +144,18 @@ export interface ObjectiveUpdateRequest {
   count?: number;
 }
 
+// Hideout validation types
+export type HideoutModuleStatus = 'completed' | 'uncompleted';
+
+export interface HideoutModuleUpdateRequest {
+  state: HideoutModuleStatus;
+}
+
+export interface HideoutPartUpdateRequest {
+  state?: 'completed' | 'uncompleted';
+  count?: number;
+}
+
 // Service method options
 export interface ServiceOptions {
   transaction?: FirebaseFirestore.Transaction;


### PR DESCRIPTION
## Summary

Fixes #163

This PR adds new API endpoints to manage hideout progression, mirroring the existing task progress API while keeping the current data model and conventions.

- Add types and validation for hideout module/part updates.
- Add service methods in `ProgressService` to update hideout modules and parts in a game-mode-aware way.
- Add HTTP handlers and OpenAPI documentation comments for the new endpoints.
- Register the new routes under both `/api` and `/api/v2`.

## Changes

### 1. API types

**File:** `functions/src/types/api.ts`

- Add hideout validation types:
  - `HideoutModuleStatus = 'completed' | 'uncompleted'`
  - `HideoutModuleUpdateRequest { state: HideoutModuleStatus }`
  - `HideoutPartUpdateRequest { state?: 'completed' | 'uncompleted'; count?: number }`

These mirror the existing `TaskStatus` / `TaskUpdateRequest` / `ObjectiveUpdateRequest` types but for hideout modules and parts.

### 2. ValidationService

**File:** `functions/src/services/ValidationService.ts`

- Extend imports to include the new hideout types.
- Add validators:
  - `validateHideoutModuleStatus(status)`
  - `validateHideoutModuleUpdate(body)`
  - `validateHideoutPartUpdate(body)`
  - `validateModuleId(moduleId)`
  - `validatePartId(partId)`

These follow the same patterns and error messages as:

- `validateTaskStatus`
- `validateTaskUpdate`
- `validateObjectiveUpdate`
- `validateTaskId` / `validateObjectiveId`

### 3. ProgressService

**File:** `functions/src/services/ProgressService.ts`

- Extend imports from `../types/api.js` to include:
  - `HideoutModuleStatus`
  - `HideoutModuleUpdateRequest`
  - `HideoutPartUpdateRequest`

- Add methods:

  - `updateHideoutModule(userId, moduleId, state, gameMode)`
    - Writes to `${gameMode}.hideoutModules.${moduleId}`.
    - `completed` → `complete = true`, `timestamp = now`.
    - `uncompleted` → `complete = false`, `timestamp` deleted.

  - `updateHideoutPart(userId, partId, update, gameMode)`
    - Writes to `${gameMode}.hideoutParts.${partId}`.
    - If `state` is provided, toggles `complete` and `timestamp` the same way as task objectives.
    - If `count` is provided, updates `${baseKey}.count`.

Both methods use the same logging and error patterns as `updateTaskObjective`.

### 4. HTTP handlers and OpenAPI

**File:** `functions/src/handlers/progressHandler.ts`

- Add handler: `updateHideoutModule`
  - Route: `POST /progress/hideout/module/{moduleId}`
  - Permission: requires `WP`.
  - Uses:
    - `validateUserId`
    - `validateModuleId`
    - `validateHideoutModuleUpdate`
  - Resolves `gameMode` the same way as `updateSingleTask`.
  - Calls `progressService.updateHideoutModule` and returns:

    ```json
    {
      "success": true,
      "data": {
        "moduleId": "...",
        "state": "completed | uncompleted",
        "message": "Hideout module updated successfully"
      }
    }
    ```

  - Includes a full `@openapi` block similar to the existing task update endpoint.

- Add handler: `updateHideoutPart`
  - Route: `POST /progress/hideout/part/{partId}`
  - Permission: requires `WP`.
  - Uses:
    - `validateUserId`
    - `validatePartId`
    - `validateHideoutPartUpdate`
  - Same `gameMode` resolution as other progress endpoints.
  - Calls `progressService.updateHideoutPart` and returns:

    ```json
    {
      "success": true,
      "data": {
        "partId": "...",
        "state": "completed | uncompleted | undefined",
        "count": 0,
        "message": "Hideout part updated successfully"
      }
    }
    ```

  - Includes a full `@openapi` block similar to `updateTaskObjective`.

- Update the default export to include the two new handlers:

  - `updateHideoutModule`
  - `updateHideoutPart`

### 5. Route registration

**File:** `functions/src/index.ts`

- Under `/api` scope:

  - `POST /api/progress/hideout/module/:moduleId` → `progressHandler.updateHideoutModule`
  - `POST /api/progress/hideout/part/:partId` → `progressHandler.updateHideoutPart`

- Under `/api/v2` scope:

  - `POST /api/v2/progress/hideout/module/:moduleId` → `progressHandler.updateHideoutModule`
  - `POST /api/v2/progress/hideout/part/:partId` → `progressHandler.updateHideoutPart`

These mirror the existing task progress routes so that hideout progression can be managed in both API versions.

## Rationale

- Hideout progression is already exposed in the formatted progress (`hideoutModulesProgress`, `hideoutPartsProgress`), but there was no public API to update this state in a controlled way.
- These endpoints mirror the existing task progress API patterns (single item + objective/part) and reuse the same error handling, logging and game mode handling.
- This enables external tools (like TarkovTracker clients or integrations) to manage hideout upgrades and their item requirements via the official API.

## Notes

- The new types and validators are additive and should be backwards compatible.
- No changes were made to the internal progress formatting logic (`formatProgress`), only to the write path.
- If you prefer different route shapes (e.g. `/progress/hideout/{moduleId}` instead of `/progress/hideout/module/{moduleId}`), I am happy to adjust the paths to match your naming conventions.
